### PR TITLE
Simplify build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "gypfile": true,
   "scripts": {
     "preinstall": "node scripts/get-dist.js",
-    "install": "node-gyp --nodedir=${npm_config_tmp}/sslkeylog-node-v${npm_config_node_version} rebuild",
+    "install": "node-gyp --tarball=${npm_config_tmp}/sslkeylog-node-v${npm_config_node_version}.tar.gz rebuild",
     "test": "node node_modules/mocha/bin/mocha",
     "clean": "node-gyp clean && (cd examples; make clean)"
   },


### PR DESCRIPTION
We can use `--tarball` instead of `--nodedir`, that way we don't have to extract the tar and it *should* work on Windows (but I think there's a bug with that in node-gyp).

Also check that node version is >= 10, not 10 or 11.

And simplify code in general (`encoding` not needed on https options, use `stream.pipeline(...)`)