### PR TITLE
Proposal: Use SSLKEYLOGFILE variable as default

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ catch(e){
     var sslkeylog = require('./build/Debug/sslkeylog.node');
 }
 
+E.filename = process.env.SSLKEYLOGFILE;
+
 E.get_session_key = sslkeylog.get_session_key;
 
 E.set_log = filename=>{


### PR DESCRIPTION
If user doesn't call `set_log`, it'd be good to use the `SSLKEYLOGFILE` environment variable just as browsers do. WDYT?