### PR TITLE
Code refactor

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,6 +4,7 @@
         "cflags!": ["-fno-exceptions"],
         "cflags_cc!": ["-fno-exceptions"],
         "sources": [
+            "src/unwrap_ssl.cpp",
             "src/main.cpp",
         ],
         "include_dirs": [
@@ -13,8 +14,7 @@
             "<!(node -p \"require('node-addon-api').gyp\")"
         ],
         "defines": [
-            "NAPI_CPP_EXCEPTIONS", 
-            "NODE_WANT_INTERNALS=1",
+            "NAPI_CPP_EXCEPTIONS",
         ],
         "conditions": [
             ["OS=='mac'", {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,32 +6,26 @@
 #error OpenSSL 1.1.0+ required
 #endif
 
-napi_value get_client_random(napi_env env, SSL *ssl) {
-    auto buf = Napi::Buffer<unsigned char>::New(env, SSL3_RANDOM_SIZE);
-    SSL_get_client_random(ssl, buf.Data(), SSL3_RANDOM_SIZE);
-    return buf;
-};
-
-napi_value get_master_key(napi_env env, SSL *ssl) {
-    auto buf = Napi::Buffer<unsigned char>::New(env, SSL_MAX_MASTER_KEY_LENGTH);
-    SSL_SESSION *session = SSL_get_session(ssl);
-    if (!session)
-        throw Napi::Error::New(env, "No TLS session present");
-    SSL_SESSION_get_master_key(session, buf.Data(), SSL_MAX_MASTER_KEY_LENGTH);
-    return buf;
-};
-
 Napi::Object get_session_key(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
 
     if (info.Length()<1 || !info[0].IsObject())
-        throw Napi::TypeError::New(env, "get_session_key() expects object");
+        throw Napi::TypeError::New(env, "get_session_key() expects TLSSocket argument");
 
     SSL* ssl = unwrap_ssl(env, info[0].As<Napi::Object>());
+    SSL_SESSION* session = SSL_get_session(ssl);
+    if (!session)
+        throw Napi::Error::New(env, "No TLS session present");
 
-    Napi::Object result = Napi::Object::New(env);   
-    result.Set("client_random", get_client_random(env, ssl));
-    result.Set("master_key", get_master_key(env, ssl));
+    auto buf1 = Napi::Buffer<unsigned char>::New(env, SSL3_RANDOM_SIZE);
+    SSL_get_client_random(ssl, buf1.Data(), SSL3_RANDOM_SIZE);
+
+    auto buf2 = Napi::Buffer<unsigned char>::New(env, SSL_MAX_MASTER_KEY_LENGTH);
+    SSL_SESSION_get_master_key(session, buf2.Data(), SSL_MAX_MASTER_KEY_LENGTH);
+
+    Napi::Object result = Napi::Object::New(env);
+    result.Set("client_random", buf1);
+    result.Set("master_key", buf2);
     return result;
 }
 
@@ -40,4 +34,4 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
     return exports;
 }
 
-NODE_API_MODULE(sslkeylog, init)
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,8 @@ napi_value get_client_random(napi_env env, SSL *ssl) {
 napi_value get_master_key(napi_env env, SSL *ssl) {
     auto buf = Napi::Buffer<unsigned char>::New(env, SSL_MAX_MASTER_KEY_LENGTH);
     SSL_SESSION *session = SSL_get_session(ssl);
+    if (!session)
+        throw Napi::Error::New(env, "No TLS session present");
     SSL_SESSION_get_master_key(session, buf.Data(), SSL_MAX_MASTER_KEY_LENGTH);
     return buf;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,21 +1,10 @@
 #include <napi.h>
-#include <node.h>
-#include <tls_wrap.h>
 #include <openssl/ssl.h>
-
-using v8::Local;
-using v8::Value;
-using v8::String;
-using v8::Object;
-using v8::Isolate;
+#include "unwrap_ssl.h"
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000
 #error OpenSSL 1.1.0+ required
 #endif
-
-class TLSWrap2 : public node::TLSWrap {
-    public: SSL *get_ssl(){ return ssl_.get(); }
-};
 
 napi_value get_client_random(napi_env env, SSL *ssl) {
     auto buf = Napi::Buffer<unsigned char>::New(env, SSL3_RANDOM_SIZE);
@@ -30,32 +19,13 @@ napi_value get_master_key(napi_env env, SSL *ssl) {
     return buf;
 };
 
-static Local<Object> v8_local_obj_from_napi_value(napi_value v) {
-  Local<Value> local;
-  memcpy(&local, &v, sizeof(v));
-  return local.As<Object>();
-}
-
-static std::string v8_local_obj_ctor(Local<Object> obj) {
-    Local<String> ctor = obj->GetConstructorName();
-    return *String::Utf8Value(Isolate::GetCurrent(), ctor);
-}
-
 Napi::Object get_session_key(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
 
     if (info.Length()<1 || !info[0].IsObject())
         throw Napi::TypeError::New(env, "get_session_key() expects object");
-    
-    Napi::Value ssl_prop = info[0].As<Napi::Object>().Get("ssl");
-    if (!ssl_prop.IsObject())
-        throw Napi::TypeError::New(env, "'ssl' property is not an object");
 
-    Local<Object> obj = v8_local_obj_from_napi_value(ssl_prop);
-    if (v8_local_obj_ctor(obj)!="TLSWrap")
-        throw Napi::TypeError::New(env, "'ssl' property is not TLSWrap");
-    TLSWrap2* tls_wrap2 = (TLSWrap2*)obj->GetAlignedPointerFromInternalField(0);
-    SSL *ssl = tls_wrap2->get_ssl();
+    SSL* ssl = unwrap_ssl(env, info[0].As<Napi::Object>());
 
     Napi::Object result = Napi::Object::New(env);   
     result.Set("client_random", get_client_random(env, ssl));

--- a/src/unwrap_ssl.cpp
+++ b/src/unwrap_ssl.cpp
@@ -2,9 +2,9 @@
 
 #define NODE_WANT_INTERNALS 1
 #include <tls_wrap.h>
-#include <js_native_api_v8.h>
 
 using v8::Local;
+using v8::Value;
 using v8::String;
 using v8::Object;
 using v8::Isolate;
@@ -13,9 +13,15 @@ class TLSWrap2 : public node::TLSWrap {
     public: SSL* get_ssl(){ return ssl_.get(); }
 };
 
-std::string v8_local_obj_ctor(Local<Object> obj) {
+static std::string v8_local_obj_ctor(Local<Object> obj) {
     Local<String> ctor = obj->GetConstructorName();
     return *String::Utf8Value(Isolate::GetCurrent(), ctor);
+}
+
+static Local<Object> v8_local_obj_from_napi_value(napi_value v) {
+  Local<Value> local;
+  memcpy(&local, &v, sizeof(v));
+  return local.As<Object>();
 }
 
 SSL* unwrap_ssl(napi_env env, Napi::Object socket) {
@@ -23,7 +29,7 @@ SSL* unwrap_ssl(napi_env env, Napi::Object socket) {
     if (!wrap_js.IsObject())
         throw Napi::TypeError::New(env, "'_handle' property is not an object");
 
-    Local<Object> wrap_v8 = v8impl::V8LocalValueFromJsValue(wrap_js).As<Object>();
+    Local<Object> wrap_v8 = v8_local_obj_from_napi_value(wrap_js);
     if (v8_local_obj_ctor(wrap_v8)!="TLSWrap")
         throw Napi::TypeError::New(env, "'_handle' property is not TLSWrap");
     return TLSWrap2::FromJSObject<TLSWrap2>(wrap_v8)->get_ssl();

--- a/src/unwrap_ssl.cpp
+++ b/src/unwrap_ssl.cpp
@@ -1,0 +1,30 @@
+#include "unwrap_ssl.h"
+
+#define NODE_WANT_INTERNALS 1
+#include <tls_wrap.h>
+#include <js_native_api_v8.h>
+
+using v8::Local;
+using v8::String;
+using v8::Object;
+using v8::Isolate;
+
+class TLSWrap2 : public node::TLSWrap {
+    public: SSL* get_ssl(){ return ssl_.get(); }
+};
+
+std::string v8_local_obj_ctor(Local<Object> obj) {
+    Local<String> ctor = obj->GetConstructorName();
+    return *String::Utf8Value(Isolate::GetCurrent(), ctor);
+}
+
+SSL* unwrap_ssl(napi_env env, Napi::Object socket) {
+    Napi::Value wrap_js = socket.Get("_handle");
+    if (!wrap_js.IsObject())
+        throw Napi::TypeError::New(env, "'_handle' property is not an object");
+
+    Local<Object> wrap_v8 = v8impl::V8LocalValueFromJsValue(wrap_js).As<Object>();
+    if (v8_local_obj_ctor(wrap_v8)!="TLSWrap")
+        throw Napi::TypeError::New(env, "'_handle' property is not TLSWrap");
+    return TLSWrap2::FromJSObject<TLSWrap2>(wrap_v8)->get_ssl();
+}

--- a/src/unwrap_ssl.h
+++ b/src/unwrap_ssl.h
@@ -1,0 +1,13 @@
+#ifndef __UNWRAP_SSL_H_
+#define __UNWRAP_SSL_H_
+
+#include <napi.h>
+#include <openssl/ssl.h>
+
+/**
+ * Returns the OpenSSL context for a given N-API value referring
+ * to a `tls.TLSSocket` object.
+ */
+SSL* unwrap_ssl(napi_env env, Napi::Object socket);
+
+#endif


### PR DESCRIPTION
This PR does 2 main things:

1. Separate code dealing with Node.JS internals into its own file.

2. Check that session exists, to avoid crashing Node when the module is used incorrectly:

   ~~~ js
   sslkeylog.set_log("...");
   const req = https.get("https://example.org");
   req.on("socket", () => sslkeylog.update_log(socket));
   ~~~

Also simplify code (use `V8LocalValueFromJsValue()`, etc.)