### PR TITLE
Polyfill for keylog API

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,6 +3,8 @@
         "target_name": "sslkeylog",
         "cflags!": ["-fno-exceptions"],
         "cflags_cc!": ["-fno-exceptions"],
+        # we're accessing internals, disable inlining to prevent crashes
+        "cflags": ["-fno-inline -fno-early-inlining"],
         "sources": [
             "src/unwrap_ssl.cpp",
             "src/main.cpp",

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ catch(e){
 
 E.filename = process.env.SSLKEYLOGFILE;
 
-E.get_session_key = sslkeylog.get_session_key;
+E.get_session_key = tls_socket=>
+    sslkeylog.get_session_key(tls_socket._handle);
 
 E.set_log = filename=>{
     E.filename = filename;
@@ -19,7 +20,7 @@ E.set_log = filename=>{
 E.update_log = tls_socket=>{
     if (!E.filename)
         return;
-    const {client_random, master_key} = sslkeylog.get_session_key(tls_socket);
+    const {client_random, master_key} = E.get_session_key(tls_socket);
     const hex1 = client_random.toString('hex');
     const hex2 = master_key.toString('hex');
     fs.appendFileSync(E.filename, `CLIENT_RANDOM ${hex1} ${hex2}\n`);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const E = exports;
 
+require('./lib/polyfill');
+
 try { var sslkeylog = require('./build/Release/sslkeylog.node'); }
 catch(e){
     if (e.code!=='MODULE_NOT_FOUND') throw e;

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,0 +1,28 @@
+const tls = require('tls');
+
+// Determine if native API present
+const socket = tls.connect({ port: 1 });
+exports.nativeApiPresent = (typeof socket._handle.enableKeylogCallback !== 'undefined');
+socket.destroy();
+
+// Logic to load native addon
+exports.loadNativeAddon = () => {
+    try {
+        return require('../build/Release/sslkeylog.node');
+    } catch(e) {
+        if (e.code!=='MODULE_NOT_FOUND') throw e;
+        return require('../build/Debug/sslkeylog.node');
+    }
+};
+
+// Logic to patch TLSSocket constructor
+exports.patchSocket = (afterConstruct) => {
+    // For now we'll do it by patching _init()... not exactly like
+    // patching constructor, but close and less invasive.
+    const original = tls.TLSSocket.prototype._init;
+    tls.TLSSocket.prototype._init = function() {
+        const ret = original.apply(this, arguments);
+        afterConstruct.call(this);
+        return ret;
+    };
+};

--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -1,0 +1,58 @@
+const common = require('./common');
+
+// If the native API is present, we don't need to polyfill
+if (common.nativeApiPresent)
+    return;
+
+const native = common.loadNativeAddon();
+let polyfillKeylog;
+
+if (native.enable_keylog_callback) {
+    // The keylog API is available natively, we just have to expose it!
+    polyfillKeylog = socket => {
+        const ssl = socket._handle;
+        ssl.onkeylog = (line) => emitKeylog(socket, line);
+        native.enable_keylog_callback(ssl);
+    };
+} else {
+    // No keylog API, but this also means OpenSSL doesn't support TLSv1.3.
+    // Since all connections will be TLSv1.2 or older, we can emulate the
+    // keylog API by manually generating a `CLIENT_RANDOM` line after the
+    // handshake (and after renegotiations).
+    polyfillKeylog = socket => {
+        // Use the undocumented 'secure' event, with is emitted before Node.JS
+        // makes final checks and emits 'secureConnect' or 'secureConnection'.
+        socket.prependListener('secure', () =>
+            emitKeylog(socket, dumpKey(socket)));
+    };
+
+    function dumpKey(socket) {
+        const data = native.get_session_key(socket._handle);
+        const rand = data.client_random.toString('hex');
+        const key = data.master_key.toString('hex');
+        return Buffer.from(`CLIENT_RANDOM ${rand} ${key}\n`);
+    }
+}
+
+// Patch the socket constructor to invoke the polyfill when needed
+common.patchSocket(function() {
+    if (this._tlsOptions.isServer) {
+        if (this.server && this.server.listenerCount('keylog') > 0)
+            polyfillKeylog(this);
+    } else {
+        this.on('newListener', newListener);
+        function newListener(event) {
+            if (event !== 'keylog')
+                return;
+            polyfillKeylog(this);
+            this.removeListener('newListener', newListener);
+        }
+    }
+});
+
+function emitKeylog(socket, line) {
+    if (socket._tlsOptions.isServer)
+        socket.server.emit('keylog', line, socket);
+    else
+        socket.emit('keylog', line);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,9 +10,9 @@ Napi::Object get_session_key(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
 
     if (info.Length()<1 || !info[0].IsObject())
-        throw Napi::TypeError::New(env, "get_session_key() expects TLSSocket argument");
+        throw Napi::TypeError::New(env, "get_session_key() expects TLSWrap argument");
 
-    SSL* ssl = unwrap_ssl(env, info[0].As<Napi::Object>());
+    SSL* ssl = unwrap_ssl(env, info[0]);
     SSL_SESSION* session = SSL_get_session(ssl);
     if (!session)
         throw Napi::Error::New(env, "No TLS session present");

--- a/src/unwrap_ssl.cpp
+++ b/src/unwrap_ssl.cpp
@@ -8,6 +8,7 @@ using v8::Value;
 using v8::String;
 using v8::Object;
 using v8::Isolate;
+using v8::HandleScope;
 
 #if NODE_VERSION_AT_LEAST(10,2,0)
 #define UNWRAP_PTR(x) (x).get()
@@ -18,6 +19,8 @@ using v8::Isolate;
 class TLSWrap2 : public node::TLSWrap {
     public:
     SSL* get_ssl(){ return UNWRAP_PTR(ssl_); }
+    SSL_CTX* get_ctx(){ return UNWRAP_PTR(sc_->ctx_); }
+    node::Environment* get_env(){ return ssl_env(); }
 };
 
 static std::string v8_local_obj_ctor(Local<Object> obj) {
@@ -36,4 +39,23 @@ SSL* unwrap_ssl(napi_env env, napi_value wrap) {
     if (v8_local_obj_ctor(wrap_v8)!="TLSWrap")
         throw Napi::TypeError::New(env, "'_handle' property is not TLSWrap");
     return node::Unwrap<TLSWrap2>(wrap_v8)->get_ssl();
+}
+
+SSL_CTX* unwrap_ssl_ctx(napi_env env, napi_value wrap) {
+    Local<Object> wrap_v8 = v8_local_obj_from_napi_value(wrap);
+    if (v8_local_obj_ctor(wrap_v8)!="TLSWrap")
+        throw Napi::TypeError::New(env, "'_handle' property is not TLSWrap");
+    return node::Unwrap<TLSWrap2>(wrap_v8)->get_ctx();
+}
+
+void call_with_data(const SSL* s, const char* name, const char* data, size_t size) {
+    TLSWrap2* w = static_cast<TLSWrap2*>(SSL_get_app_data(s));
+    node::Environment* env = w->get_env();
+    Isolate* isolate = Isolate::GetCurrent(); // env->isolate() returns an invalid(?) one on Release builds
+    HandleScope handle_scope(isolate);
+    //Context::Scope context_scope(env->context()); // same with env->context()
+
+    Local<String> method = String::NewFromUtf8(isolate, name, v8::NewStringType::kNormal).ToLocalChecked();
+    Local<Value> buffer = node::Buffer::Copy(env, data, size).ToLocalChecked();
+    w->MakeCallback(method, 1, &buffer);
 }

--- a/src/unwrap_ssl.cpp
+++ b/src/unwrap_ssl.cpp
@@ -30,12 +30,8 @@ static Local<Object> v8_local_obj_from_napi_value(napi_value v) {
   return local.As<Object>();
 }
 
-SSL* unwrap_ssl(napi_env env, Napi::Object socket) {
-    Napi::Value wrap_js = socket.Get("_handle");
-    if (!wrap_js.IsObject())
-        throw Napi::TypeError::New(env, "'_handle' property is not an object");
-
-    Local<Object> wrap_v8 = v8_local_obj_from_napi_value(wrap_js);
+SSL* unwrap_ssl(napi_env env, napi_value wrap) {
+    Local<Object> wrap_v8 = v8_local_obj_from_napi_value(wrap);
     if (v8_local_obj_ctor(wrap_v8)!="TLSWrap")
         throw Napi::TypeError::New(env, "'_handle' property is not TLSWrap");
     return node::Unwrap<TLSWrap2>(wrap_v8)->get_ssl();

--- a/src/unwrap_ssl.cpp
+++ b/src/unwrap_ssl.cpp
@@ -9,14 +9,15 @@ using v8::String;
 using v8::Object;
 using v8::Isolate;
 
-class TLSWrap2 : public node::TLSWrap {
-    public: SSL* get_ssl(){
 #if NODE_VERSION_AT_LEAST(10,2,0)
-        return ssl_.get();
+#define UNWRAP_PTR(x) (x).get()
 #else
-        return ssl_;
+#define UNWRAP_PTR(x) (x)
 #endif
-    }
+
+class TLSWrap2 : public node::TLSWrap {
+    public:
+    SSL* get_ssl(){ return UNWRAP_PTR(ssl_); }
 };
 
 static std::string v8_local_obj_ctor(Local<Object> obj) {
@@ -25,9 +26,9 @@ static std::string v8_local_obj_ctor(Local<Object> obj) {
 }
 
 static Local<Object> v8_local_obj_from_napi_value(napi_value v) {
-  Local<Value> local;
-  memcpy(&local, &v, sizeof(v));
-  return local.As<Object>();
+    Local<Value> local;
+    memcpy(&local, &v, sizeof(v));
+    return local.As<Object>();
 }
 
 SSL* unwrap_ssl(napi_env env, napi_value wrap) {

--- a/src/unwrap_ssl.h
+++ b/src/unwrap_ssl.h
@@ -10,4 +10,17 @@
  */
 SSL* unwrap_ssl(napi_env env, napi_value wrap);
 
+/**
+ * Returns the OpenSSL context for a given N-API value referring
+ * to a `TLSWrap` object.
+ */
+SSL_CTX* unwrap_ssl_ctx(napi_env env, napi_value wrap);
+
+/**
+ * Call the passed property on the `TLSWrap` object associated with
+ * the SSL connection. The method will be called with a single `Buffer`
+ * argument containing the supplied data.
+ */
+void call_with_data(const SSL* s, const char* name, const char* data, size_t size);
+
 #endif

--- a/src/unwrap_ssl.h
+++ b/src/unwrap_ssl.h
@@ -5,9 +5,9 @@
 #include <openssl/ssl.h>
 
 /**
- * Returns the OpenSSL context for a given N-API value referring
- * to a `tls.TLSSocket` object.
+ * Returns the OpenSSL connection for a given N-API value referring
+ * to a `TLSWrap` object.
  */
-SSL* unwrap_ssl(napi_env env, Napi::Object socket);
+SSL* unwrap_ssl(napi_env env, napi_value wrap);
 
 #endif

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,82 @@
 'use strict';
+const util = require('util');
 const assert = require('assert');
+const tls = require('tls');
 const https = require('https');
 const path = require('path');
 const fs = require('fs');
 const sslkeylog = require('../index.js');
+
+const renegotiate = util.promisify( (socket, ...args) => assert(socket.renegotiate(...args)) );
+const once = (obj, event)=>new Promise((resolve, reject)=>{
+    function listener() {
+        resolve(Array.from(arguments));
+        obj.removeListener('error', errorListener);
+    }
+    function errorListener(err) {
+        reject(err);
+        obj.removeListener(event, listener);
+    }
+    obj.once(event, listener).once('error', errorListener);
+});
+
+const boundServer = async (type, options, ...args) => {
+    const server = type.createServer({
+        key: fs.readFileSync(`${__dirname}/test.key`),
+        cert: fs.readFileSync(`${__dirname}/test.crt`),
+        ...options,
+    }, ...args).listen();
+    return once(server, 'listening').then(() => server);
+};
+const makeClient = (server, func, options) => func({
+    port: server.address().port,
+    rejectUnauthorized: false,
+    ...options,
+});
+
+describe('keylog API polyfill', function() {
+    const assertLinesLength = (lines, length) => {
+        assert.equal(lines.client.length, length);
+        assert.equal(lines.server.length, length);
+    };
+    const withPair = (options, body) => async function() {
+        const server = await boundServer(tls, options, conn => conn.resume());
+        const client = makeClient(server, tls.connect, options);
+        try {
+            let lines = { client: [], server: [] };
+            client.on('keylog', line => lines.client.push(line));
+            server.on('keylog', line => lines.server.push(line));
+            await Promise.all([ once(server, 'secureConnection'),
+                                once(client, 'secureConnect') ]);
+            await body.call(this, server, client, lines);
+            lines.client.concat(lines.server).forEach(line =>
+                assert(Buffer.isBuffer(line) && line.length > 1 && line[line.length-1] === 0x0A));
+        } finally {
+            server.close();
+            client.end();
+        }
+    };
+    
+    it('works for TLSv1.2 and renegotiations', withPair(
+        { maxVersion: 'TLSv1.2' },
+        async (server, client, lines) => {
+            assertLinesLength(lines, 1);
+
+            client.write('hello'); // otherwise renegotiation doesn't work
+            await renegotiate(client, { rejectUnauthorized: false });
+            assertLinesLength(lines, 2);
+        }
+    ));
+    
+    it('works for TLSv1.3', withPair(
+        { minVersion: 'TLSv1.3', maxVersion: 'TLSv1.3' },
+        async function (server, client, lines) {
+            if (client.getProtocol() !== 'TLSv1.3')
+                return this.skip(); // TLSv1.3 not supported
+            assertLinesLength(lines, 5);
+        }
+    ));
+});
 
 describe('sslkeylog', function(){
     const hello = "Hello, world";


### PR DESCRIPTION
This is not (at least initially) intended to be merged, just as a proposal.
Basically implements a polyfill that:
 - for Node.JS >= 11.9.0, calls SSL_CTX_set_keylog_callback natively and emits `keylog` events based on it
 - for Node.JS < 11.9.0, emulates the OpenSSL API by manually assembling the `CLIENT_RANDOM` line as we do now, and emitting `keylog` events.
 - for Node.JS >= v12.3.0 (probably), if it detects that `keylog` is available natively, does nothing

Polyfilling the keylog API would allow us to implement `index.js` without needing the native module:

~~~ js
require('./lib/pollyfill.js');

E.filename = // ... (no changes)
E.set_log = // ... (no changes)
E.log_line = line => fs.appendFile(E.filename, line, err => {
    if (err) console.error(`Warning: Failed to log to SSLKEYLOGFILE: ${err}`);
});

E.hook_socket = socket => socket.on('keylog', E.log_line);
E.hook_server = server => server.on('keylog', E.log_line);
E.hook_agent = // ... (no changes)
E.hook_all = // ... (no changes)
~~~

Which would in turn allow us to skip building the native module entirely, if the native API is present. So, for recent Node.JS versions, this would simply be a small JS module for easy SSLKEYLOGFILE logging.

The downside is that we'd have to drop `update_log` and `get_session_key`. If someone needs custom logging he can subscribe to `keylog` directly, and only use this module as a polyfill. The second one is not entirely replaceable, but you can parse `keylog` lines to get the secrets you need (with TLSv1.3 this should be even more reliable than calling `get_session_key` manually, IMHO). What are your thoughts on this?