### PR TITLE
Fix hookAll()

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Returns the module object.
 
  - `socket` (`tls.TLSSocket`): Socket to log decryption keys for.
 
-Log keys for a particular socket. This method must be called after creating
+Log keys for a particular client socket. This method must be called after creating
 the socket (i.e. at the same event loop tick) to guarantee that all keys are
 logged. Logging the same socket multiple times has no effect.
 
@@ -183,6 +183,8 @@ Returns the passed socket.
  - `server` (`tls.Server`): Server to log decryption keys for.
 
 Log keys for all (future) incoming connections to the passed server.
+Logging the same server multiple times has no effect.
+
 Returns the passed server.
 
 ### hookAgent(agent)

--- a/index.js
+++ b/index.js
@@ -34,8 +34,17 @@ E.hookAgent = agent => {
     return agent;
 };
 
+let nologWarningEmitted = false;
+function emitNologWarning() {
+    if (nologWarningEmitted) return;
+    console.error('Warning: TLS secrets will NOT be logged for server sockets without an associated tls.Server');
+    nologWarningEmitted = true;
+}
+
 E.hookAll = () => common.patchSocket(function () {
-    if (this._tlsOptions.isServer && this.server) {
+    if (this._tlsOptions.isServer) {
+        if (!this.server)
+            return emitNologWarning();
         this._handle.enableKeylogCallback();
         E.hookServer(this.server);
     } else {

--- a/index.js
+++ b/index.js
@@ -43,9 +43,9 @@ function emitNologWarning() {
 
 E.hookAll = () => common.patchSocket(function () {
     if (this._tlsOptions.isServer) {
-        if (!this.server)
+        if (!this._tlsOptions.server)
             return emitNologWarning();
-        E.hookServer(this.server);
+        E.hookServer(this._tlsOptions.server);
     }
 }, function () {
     if (!this._tlsOptions.isServer)

--- a/index.js
+++ b/index.js
@@ -45,9 +45,9 @@ E.hookAll = () => common.patchSocket(function () {
     if (this._tlsOptions.isServer) {
         if (!this.server)
             return emitNologWarning();
-        this._handle.enableKeylogCallback();
         E.hookServer(this.server);
-    } else {
-        E.hookSocket(this);
     }
+}, function () {
+    if (!this._tlsOptions.isServer)
+        E.hookSocket(this);
 });

--- a/index.js
+++ b/index.js
@@ -35,5 +35,10 @@ E.hookAgent = agent => {
 };
 
 E.hookAll = () => common.patchSocket(function () {
-    E.hookSocket(this);
+    if (this._tlsOptions.isServer && this.server) {
+        this._handle.enableKeylogCallback();
+        E.hookServer(this.server);
+    } else {
+        E.hookSocket(this);
+    }
 });

--- a/lib/common.js
+++ b/lib/common.js
@@ -16,13 +16,14 @@ exports.loadNativeAddon = () => {
 };
 
 // Logic to patch TLSSocket constructor
-exports.patchSocket = (afterConstruct) => {
+exports.patchSocket = (beforeInit, afterInit) => {
     // For now we'll do it by patching _init()... not exactly like
     // patching constructor, but close and less invasive.
     const original = tls.TLSSocket.prototype._init;
     tls.TLSSocket.prototype._init = function() {
+        beforeInit.call(this);
         const ret = original.apply(this, arguments);
-        afterConstruct.call(this);
+        afterInit.call(this);
         return ret;
     };
 };

--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -35,7 +35,7 @@ if (native.enable_keylog_callback) {
 }
 
 // Patch the socket constructor to invoke the polyfill when needed
-common.patchSocket(function() {
+common.patchSocket(() => {}, function() {
     if (this._tlsOptions.isServer) {
         if (this.server && this.server.listenerCount('keylog') > 0)
             polyfillKeylog(this);


### PR DESCRIPTION
I didn't realize that `hookClient` only works on client sockets. Server sockets *don't* emit `keylog` events.

So, mention this in the docs, and fix `hookAll` to hook servers as well. It'd be ideal to hook `tls.Server` constructor, but there's no easy way to do so :(